### PR TITLE
fixed saveMedia function missing required parameter for uploadWeb

### DIFF
--- a/app/Controllers/UploadController.php
+++ b/app/Controllers/UploadController.php
@@ -59,7 +59,7 @@ class UploadController extends Controller
         }
 
         try {
-            $response = $this->saveMedia($response, $file, $user);
+            $response = $this->saveMedia($response, $file, $user, param($request, 'code'));
             $this->setSessionQuotaInfo($user->current_disk_quota + $file->getSize(), $user->max_disk_quota);
         } catch (Exception $e) {
             $this->updateUserQuota($request, $user->id, $file->getSize(), true);


### PR DESCRIPTION
When choosing to upload any file using the web portal, it would cause an slim application error because the saveMedia function was missing an required parameter, as you can see in issue #627 that this pull request closes. Luckily though, uploading with an endpoint still works as expected